### PR TITLE
refactor(log): introduce shared consoleLogger for warn/error

### DIFF
--- a/src/google/image_search.ts
+++ b/src/google/image_search.ts
@@ -1,3 +1,5 @@
+import { consoleLogger as logger } from '../lib/logger'
+
 type result = {
   items?: Array<{
     link?: string | null
@@ -41,7 +43,7 @@ export class GoogleImageSearch<E extends GoogleImageEnv> {
     const res = await fetcher(url)
     if (!res.ok) {
       const body = await res.text().catch(() => '')
-      console.warn('GoogleImageSearch: CSE request failed', {
+      logger.warn('GoogleImageSearch: CSE request failed', {
         status: res.status,
         statusText: res.statusText,
         body: body.slice(0, 500),
@@ -52,7 +54,7 @@ export class GoogleImageSearch<E extends GoogleImageEnv> {
     const total = result.items?.length ?? 0
     const filtered = (result.items ?? []).map((i) => i.link).filter((l): l is string => !!l && !isBlockedUrl(l))
     if (filtered.length === 0) {
-      console.warn('GoogleImageSearch: no urls after filter', { q, total, filtered: filtered.length })
+      logger.warn('GoogleImageSearch: no urls after filter', { q, total, filtered: filtered.length })
     }
     return filtered
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import { OpenAI, OpenAIEnv } from "./openai/completions";
 import { chat } from "./slack/chat";
 import { keshite } from "./slack/keshite";
 import { ping } from "./slack/ping";
+import { consoleLogger as logger } from "./lib/logger";
 
 type Env = SlackOAuthAndOIDCEnv & GoogleImageEnv & OpenAIEnv & {
   JPI_SIGNING_SECRET: string,
@@ -27,7 +28,7 @@ export default {
 
     if (url.pathname === "/jpi/img") {
       if (!env.JPI_SIGNING_SECRET) {
-        console.error("JPI_SIGNING_SECRET is not configured")
+        logger.error("JPI_SIGNING_SECRET is not configured")
         return new Response("misconfigured", { status: 500 })
       }
       return handleJpiImage(request, {

--- a/src/jpi/image_endpoint.ts
+++ b/src/jpi/image_endpoint.ts
@@ -1,4 +1,5 @@
 import { GoogleImageEnv, GoogleImageSearch } from '../google/image_search'
+import { consoleLogger as logger } from '../lib/logger'
 import { verify } from './signature'
 
 // Minimal R2 surface we use. Avoids pulling @cloudflare/workers-types'
@@ -131,14 +132,14 @@ export async function handleJpiImage<E extends GoogleImageEnv>(
         // Same rule as upstream — guard against historical entries with missing
         // or non-image metadata that would make Slack reject the block.
         if (!ALLOWED_IMAGE_TYPES.test(contentType)) {
-          console.warn('handleJpiImage: R2 object content-type not allowed', { q, contentType })
+          logger.warn('handleJpiImage: R2 object content-type not allowed', { q, contentType })
         } else {
           const buf = await obj.arrayBuffer()
           return respond(imageResponse(buf, contentType))
         }
       }
     } catch (e) {
-      console.warn('handleJpiImage: R2 get failed, falling through to CSE', { q, error: String(e) })
+      logger.warn('handleJpiImage: R2 get failed, falling through to CSE', { q, error: String(e) })
     }
   }
 
@@ -146,7 +147,7 @@ export async function handleJpiImage<E extends GoogleImageEnv>(
   try {
     urls = await search.image_urls(q)
   } catch (e) {
-    console.warn('handleJpiImage: search threw', { q, error: String(e) })
+    logger.warn('handleJpiImage: search threw', { q, error: String(e) })
     return respond(placeholderResponse())
   }
 
@@ -162,12 +163,12 @@ export async function handleJpiImage<E extends GoogleImageEnv>(
       headers: { 'User-Agent': UPSTREAM_USER_AGENT },
     })
     if (!imgRes.ok) {
-      console.warn('handleJpiImage: upstream fetch not ok', { q, url: picked, status: imgRes.status })
+      logger.warn('handleJpiImage: upstream fetch not ok', { q, url: picked, status: imgRes.status })
       return respond(placeholderResponse())
     }
     const contentType = imgRes.headers.get('content-type') ?? ''
     if (!ALLOWED_IMAGE_TYPES.test(contentType)) {
-      console.warn('handleJpiImage: upstream content-type not allowed', { q, url: picked, contentType })
+      logger.warn('handleJpiImage: upstream content-type not allowed', { q, url: picked, contentType })
       return respond(placeholderResponse())
     }
     const buf = await imgRes.arrayBuffer()
@@ -175,14 +176,14 @@ export async function handleJpiImage<E extends GoogleImageEnv>(
     if (bucket && ctx) {
       ctx.waitUntil(
         bucket.put(objectKey, buf, { httpMetadata: { contentType } }).catch((e: unknown) => {
-          console.warn('handleJpiImage: R2 put failed', { q, error: String(e) })
+          logger.warn('handleJpiImage: R2 put failed', { q, error: String(e) })
         }),
       )
     }
 
     return respond(imageResponse(buf, contentType))
   } catch (e) {
-    console.warn('handleJpiImage: upstream fetch threw', { q, url: picked, error: String(e) })
+    logger.warn('handleJpiImage: upstream fetch threw', { q, url: picked, error: String(e) })
     return respond(placeholderResponse())
   }
 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,17 @@
+export type LogFields = Record<string, unknown>
+
+export type Logger = {
+  warn(message: string, fields?: LogFields): void
+  error(message: string, fields?: LogFields): void
+}
+
+/**
+ * Default logger that writes to the Workers runtime console. `wrangler tail
+ * --format=json` surfaces these calls as `logs[].level=warn|error` with the
+ * structured `fields` object intact, so they can be filtered/forwarded by an
+ * external log sink without further wrapping.
+ */
+export const consoleLogger: Logger = {
+  warn: (message, fields) => console.warn(message, fields ?? {}),
+  error: (message, fields) => console.error(message, fields ?? {}),
+}

--- a/src/slack/jpi.ts
+++ b/src/slack/jpi.ts
@@ -3,10 +3,11 @@ import { JSXSlack } from 'jsx-slack'
 import { NoBotMessage } from './util'
 import { jpiBlocks } from './views/jpi'
 import { buildJpiImageUrl, JpiConfig } from '../jpi/url_builder'
+import { consoleLogger as logger } from '../lib/logger'
 
 export function jpi(app: SlackApp<any> | SlackOAuthApp<any>, config: JpiConfig) {
   if (!config.imageEndpoint || !config.signingSecret) {
-    console.warn('jpi: skipping handler registration due to missing config', {
+    logger.warn('jpi: skipping handler registration due to missing config', {
       hasEndpoint: !!config.imageEndpoint,
       hasSecret: !!config.signingSecret,
     })
@@ -28,7 +29,7 @@ export function jpi(app: SlackApp<any> | SlackOAuthApp<any>, config: JpiConfig) 
         link_names: false,
       })
     } catch (e) {
-      console.warn('jpi: handler failed', { keyword, error: String(e) })
+      logger.warn('jpi: handler failed', { keyword, error: String(e) })
     }
   })
 }


### PR DESCRIPTION
## Summary
- 散在していた `console.warn` / `console.error` を `src/lib/logger.ts` の `consoleLogger` 経由に集約。
- 動作は同じ (`console.warn`/`console.error` を内部で呼ぶ。`wrangler tail --format=json` から見た `logs[].level` の値も従来通り)。
- 将来 Datadog / Sentry / Logflare 等の外部 sink に切り替えたい時、各モジュールの `import { consoleLogger as logger }` 1 行を差し替えるだけで済む構造に。
- スコープ外: `chat.ts` / `erande.ts` / `keshite.ts` 内に残る debug-only な `console.log('xxx: ', match[1])` には触らず。L-3 (`safeMessage` 適用) と合わせてどう扱うか決める方が筋。

## Test plan
- [x] `npm test` 全 37 件 green
- [x] 本番デプロイ済み (`Version ID: 27e0c79d-6198-4d42-92b4-b32cc8097e12`)
- [x] `grep 'console\.\(warn\|error\)' src/` の hit は `src/lib/logger.ts` の実装内のみ
- [x] レビュー: 既存コマンド (`!jpi`, `!chat`, `@jpi 選んで`, `@jpi 消して`, `@jpi ping`) に挙動退行なし