### PR TITLE
feat(chat): show apology in Slack when AI call fails

### DIFF
--- a/src/slack/__tests__/chat.test.ts
+++ b/src/slack/__tests__/chat.test.ts
@@ -1,0 +1,20 @@
+import { buildChatErrorReply } from '../chat'
+
+describe('buildChatErrorReply', () => {
+  it('quotes the original prompt so the user knows which request failed', () => {
+    const reply = buildChatErrorReply('明日の天気は？')
+    expect(reply).toContain('>明日の天気は？')
+  })
+
+  it('includes a Japanese apology so the user sees something instead of silence', () => {
+    const reply = buildChatErrorReply('hello')
+    expect(reply).toMatch(/応答に失敗/)
+  })
+
+  it('returns a single string (not multi-line noise)', () => {
+    const reply = buildChatErrorReply('test')
+    // quote line + apology line — at most 2 lines, no trailing whitespace
+    expect(reply.split('\n').length).toBeLessThanOrEqual(2)
+    expect(reply).toBe(reply.trim())
+  })
+})

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -2,19 +2,33 @@ import { SlackApp, SlackOAuthApp } from 'slack-cloudflare-workers'
 import { LlamaChat } from '../ai/completions'
 import { NoBotMessage, safeMessage } from './util'
 
+const pattern = /^!chat\s(.*)/
+
+export function buildChatErrorReply(prompt: string): string {
+  return `>${prompt}\n_応答に失敗しました。しばらくしてからもう一度試してください。_`
+}
+
 export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat) {
-  const pattern = /^!chat\s(.*)/
   app.message(
     pattern,
-    safeMessage(async ({ context, payload }) => {
-      if (!NoBotMessage(payload)) return
-      const match = payload.text.match(pattern)
-      if (!match || !match[1]) return
+    safeMessage(
+      async ({ context, payload }) => {
+        if (!NoBotMessage(payload)) return
+        const match = payload.text.match(pattern)
+        if (!match || !match[1]) return
 
-      const message = await client.completions(match[1])
-      await context.say({
-        text: `>${match[1]}\n${message}`,
-      })
-    }),
+        const message = await client.completions(match[1])
+        await context.say({
+          text: `>${match[1]}\n${message}`,
+        })
+      },
+      async ({ context, payload }) => {
+        const text = (payload as { text?: string }).text
+        const match = text?.match(pattern)
+        const prompt = match?.[1]
+        if (!prompt) return
+        await context.say({ text: buildChatErrorReply(prompt) })
+      },
+    ),
   )
 }


### PR DESCRIPTION
## Summary
- `safeMessage` の fallback を実装し、`LlamaChat` が throw した時に Slack へ短い謝罪メッセージを返すようにした
- 返信文字列は純粋関数 `buildChatErrorReply` に分離して 3 ケースのユニットテストでカバー
- 既存挙動 (正常系) は変更なし

## Background
旧 `!chat` の OpenAI 故障時、ユーザー側は完全に無音だった。直近の Workers AI 移行 (#47) でも同じ握りつぶし構造が残っていたため、production で AI 呼び出しが失敗すると同様にサイレントで終わる。本 PR で最低限のフィードバックを返す。

なお Slack 3 秒タイムアウト対策は不要だった。`slack-cloudflare-workers` の `app.message` ハンドラは既に lazy listener として登録され、ack は内部で即時返却される。

## Test plan
- [x] `npx jest src/slack/__tests__/chat.test.ts` (3 件 pass)
- [x] `npm test` (全 51 件 pass)
- [x] `npx tsc --noEmit` (型エラーなし)
- [ ] merge 後に `npm run deploy` を手動実行 (この repo は自動デプロイなし)
- [ ] production で `!chat <長すぎるプロンプトなど故意に失敗させる>` を試して apology が返ることを確認