### PR TITLE
feat(chat): use Slack thread as conversation history

### DIFF
--- a/src/ai/__tests__/completions.test.ts
+++ b/src/ai/__tests__/completions.test.ts
@@ -47,4 +47,31 @@ describe('LlamaChat', () => {
     const client = new LlamaChat(ai)
     await expect(client.completions('Hi')).rejects.toThrow('binding down')
   })
+
+  describe('chat (multi-turn)', () => {
+    it('prepends the system prompt to the caller-supplied messages', async () => {
+      const ai = fakeAi(async () => ({ response: 'ok' }))
+      const client = new LlamaChat(ai)
+      await client.chat([
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'reply' },
+        { role: 'user', content: 'second' },
+      ])
+
+      const [, body] = ai.run.mock.calls[0]
+      expect(body.messages).toEqual([
+        { role: 'system', content: expect.stringContaining('チャットボット') },
+        { role: 'user', content: 'first' },
+        { role: 'assistant', content: 'reply' },
+        { role: 'user', content: 'second' },
+      ])
+    })
+
+    it('returns the trimmed response just like completions does', async () => {
+      const ai = fakeAi(async () => ({ response: '  hi  ' }))
+      const client = new LlamaChat(ai)
+      const result = await client.chat([{ role: 'user', content: 'q' }])
+      expect(result).toBe('hi')
+    })
+  })
 })

--- a/src/ai/completions.ts
+++ b/src/ai/completions.ts
@@ -5,15 +5,21 @@ const SYSTEM_PROMPT =
   'あなたはチャットボットです。短い返答が望ましいです。また、特に指示が無い場合は日本語で応答してください'
 const MAX_TOKENS = 512
 
+export type ChatMessage = {
+  role: 'user' | 'assistant'
+  content: string
+}
+
 export class LlamaChat {
   constructor(private readonly ai: Ai) {}
 
   async completions(prompt: string): Promise<string> {
+    return this.chat([{ role: 'user', content: prompt }])
+  }
+
+  async chat(messages: ChatMessage[]): Promise<string> {
     const result = await this.ai.run(MODEL, {
-      messages: [
-        { role: 'system', content: SYSTEM_PROMPT },
-        { role: 'user', content: prompt },
-      ],
+      messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...messages],
       max_tokens: MAX_TOKENS,
       temperature: 0.8,
     })

--- a/src/slack/__tests__/chat.test.ts
+++ b/src/slack/__tests__/chat.test.ts
@@ -1,4 +1,4 @@
-import { buildChatErrorReply, buildChatMessages } from '../chat'
+import { buildChatErrorReply, buildChatMessages, CHAT_APOLOGY } from '../chat'
 
 const BOT_ID = 'UBOT'
 
@@ -28,6 +28,18 @@ describe('buildChatMessages', () => {
     const replies = [
       { user: 'UA', text: '!chat foo' },
       { user: BOT_ID, text: '>foo\nbar baz' },
+      { user: 'UA', text: '!chat next' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, 'next')[1]).toEqual({
+      role: 'assistant',
+      content: 'bar baz',
+    })
+  })
+
+  it('keeps unquoted bot replies as assistant content (thread replies are now quote-less)', () => {
+    const replies = [
+      { user: 'UA', text: '!chat foo' },
+      { user: BOT_ID, text: 'bar baz' },
       { user: 'UA', text: '!chat next' },
     ]
     expect(buildChatMessages(replies, BOT_ID, 'next')[1]).toEqual({
@@ -103,5 +115,9 @@ describe('buildChatErrorReply', () => {
     // quote line + apology line — at most 2 lines, no trailing whitespace
     expect(reply.split('\n').length).toBeLessThanOrEqual(2)
     expect(reply).toBe(reply.trim())
+  })
+
+  it('embeds CHAT_APOLOGY so thread replies can reuse the same copy', () => {
+    expect(buildChatErrorReply('whatever')).toContain(CHAT_APOLOGY)
   })
 })

--- a/src/slack/__tests__/chat.test.ts
+++ b/src/slack/__tests__/chat.test.ts
@@ -97,6 +97,31 @@ describe('buildChatMessages', () => {
       content: 'NEW',
     })
   })
+
+  it('skips the reply whose ts matches currentTs (not necessarily the last entry)', () => {
+    const replies = [
+      { user: 'UA', text: '!chat one', ts: '1.001' },
+      { user: 'UA', text: '!chat TRIGGER', ts: '1.002' },
+      { user: 'UA', text: '!chat later', ts: '1.003' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, 'TRIGGER', '1.002')).toEqual([
+      { role: 'user', content: 'one' },
+      { role: 'user', content: 'later' },
+      { role: 'user', content: 'TRIGGER' },
+    ])
+  })
+
+  it('processes every reply when currentTs is given but no entry matches', () => {
+    const replies = [
+      { user: 'UA', text: '!chat one', ts: '1.001' },
+      { user: 'UA', text: '!chat two', ts: '1.002' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, 'now', '9.999')).toEqual([
+      { role: 'user', content: 'one' },
+      { role: 'user', content: 'two' },
+      { role: 'user', content: 'now' },
+    ])
+  })
 })
 
 describe('buildChatErrorReply', () => {

--- a/src/slack/__tests__/chat.test.ts
+++ b/src/slack/__tests__/chat.test.ts
@@ -1,4 +1,91 @@
-import { buildChatErrorReply } from '../chat'
+import { buildChatErrorReply, buildChatMessages } from '../chat'
+
+const BOT_ID = 'UBOT'
+
+describe('buildChatMessages', () => {
+  it('returns just the current prompt when there is no thread history', () => {
+    expect(buildChatMessages(null, BOT_ID, 'hi')).toEqual([{ role: 'user', content: 'hi' }])
+  })
+
+  it('returns just the current prompt when history is empty', () => {
+    expect(buildChatMessages([], BOT_ID, 'hi')).toEqual([{ role: 'user', content: 'hi' }])
+  })
+
+  it('classifies bot messages as assistant and other users as user', () => {
+    const replies = [
+      { user: 'UALICE', text: '!chat こんにちは' },
+      { user: BOT_ID, text: '>こんにちは\nやあ' },
+      { user: 'UALICE', text: '!chat 今何時？' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, '今何時？')).toEqual([
+      { role: 'user', content: 'こんにちは' },
+      { role: 'assistant', content: 'やあ' },
+      { role: 'user', content: '今何時？' },
+    ])
+  })
+
+  it('strips the leading quote line from bot replies', () => {
+    const replies = [
+      { user: 'UA', text: '!chat foo' },
+      { user: BOT_ID, text: '>foo\nbar baz' },
+      { user: 'UA', text: '!chat next' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, 'next')[1]).toEqual({
+      role: 'assistant',
+      content: 'bar baz',
+    })
+  })
+
+  it('strips the !chat prefix from user messages', () => {
+    const replies = [
+      { user: 'UA', text: '!chat foo' },
+      { user: 'UA', text: '!chat bar' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, 'bar')[0]).toEqual({
+      role: 'user',
+      content: 'foo',
+    })
+  })
+
+  it('keeps non-!chat user messages as-is (lets normal thread chatter feed context)', () => {
+    const replies = [
+      { user: 'UA', text: 'プロジェクトの進捗どう？' },
+      { user: 'UA', text: '!chat 要約して' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, '要約して')[0]).toEqual({
+      role: 'user',
+      content: 'プロジェクトの進捗どう？',
+    })
+  })
+
+  it('skips messages with a subtype (joins, file shares, etc.)', () => {
+    const replies = [
+      { user: 'UA', text: '!chat foo' },
+      { user: 'UA', text: 'noise', subtype: 'file_share' },
+      { user: 'UA', text: '!chat current' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, 'current').length).toBe(2)
+  })
+
+  it('skips messages that are empty after stripping', () => {
+    const replies = [
+      { user: 'UA', text: '!chat   ' },
+      { user: 'UA', text: '!chat real' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, 'real')).toEqual([{ role: 'user', content: 'real' }])
+  })
+
+  it('uses currentPrompt for the tail entry even if the last reply text differs', () => {
+    const replies = [
+      { user: 'UA', text: '!chat one' },
+      { user: 'UA', text: '!chat OLD' },
+    ]
+    expect(buildChatMessages(replies, BOT_ID, 'NEW')[1]).toEqual({
+      role: 'user',
+      content: 'NEW',
+    })
+  })
+})
 
 describe('buildChatErrorReply', () => {
   it('quotes the original prompt so the user knows which request failed', () => {

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -83,8 +83,8 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
       async ({ context, payload }) => {
         if (!NoBotMessage(payload)) return
         const match = payload.text.match(pattern)
-        if (!match || !match[1]) return
-        const prompt = match[1]
+        const prompt = match?.[1]?.trim()
+        if (!prompt) return
 
         const messages = await loadConversationMessages(context, payload, prompt)
         const reply = await client.chat(messages)
@@ -98,7 +98,7 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
       async ({ context, payload }) => {
         const text = (payload as { text?: string }).text
         const match = text?.match(pattern)
-        const prompt = match?.[1]
+        const prompt = match?.[1]?.trim()
         if (!prompt) return
         const threadTs = (payload as { thread_ts?: string }).thread_ts
         const inThread = Boolean(threadTs)

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -20,19 +20,22 @@ type SlackReply = {
   user?: string
   text?: string
   subtype?: string
+  ts?: string
 }
 
 export function buildChatMessages(
   replies: SlackReply[] | null,
   botUserId: string,
   currentPrompt: string,
+  currentTs?: string,
 ): ChatMessage[] {
   const current: ChatMessage = { role: 'user', content: currentPrompt }
   if (!replies || replies.length === 0) return [current]
 
+  const filtered = currentTs ? replies.filter((r) => r.ts !== currentTs) : replies.slice(0, -1)
   const messages: ChatMessage[] = []
-  for (let i = 0; i < replies.length - 1; i++) {
-    const m = transformReply(replies[i], botUserId)
+  for (const r of filtered) {
+    const m = transformReply(r, botUserId)
     if (m) messages.push(m)
   }
   messages.push(current)
@@ -67,7 +70,12 @@ async function loadConversationMessages(
       ts: threadTs,
       limit: 20,
     })
-    return buildChatMessages((res.messages as SlackReply[] | undefined) ?? null, botUserId, prompt)
+    return buildChatMessages(
+      (res.messages as SlackReply[] | undefined) ?? null,
+      botUserId,
+      prompt,
+      payload.ts,
+    )
   } catch (error) {
     logger.warn('chat: failed to load thread history', {
       error: error instanceof Error ? error.message : String(error),

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -10,8 +10,10 @@ import { NoBotMessage, safeMessage } from './util'
 
 const pattern = /^!chat\s(.*)/
 
+export const CHAT_APOLOGY = '_応答に失敗しました。しばらくしてからもう一度試してください。_'
+
 export function buildChatErrorReply(prompt: string): string {
-  return `>${prompt}\n_応答に失敗しました。しばらくしてからもう一度試してください。_`
+  return `>${prompt}\n${CHAT_APOLOGY}`
 }
 
 type SlackReply = {
@@ -86,9 +88,11 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
 
         const messages = await loadConversationMessages(context, payload, prompt)
         const reply = await client.chat(messages)
+        const inThread = Boolean(payload.thread_ts)
         await context.say({
-          text: `>${prompt}\n${reply}`,
+          text: inThread ? reply : `>${prompt}\n${reply}`,
           thread_ts: payload.thread_ts,
+          reply_broadcast: inThread,
         })
       },
       async ({ context, payload }) => {
@@ -96,9 +100,12 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
         const match = text?.match(pattern)
         const prompt = match?.[1]
         if (!prompt) return
+        const threadTs = (payload as { thread_ts?: string }).thread_ts
+        const inThread = Boolean(threadTs)
         await context.say({
-          text: buildChatErrorReply(prompt),
-          thread_ts: (payload as { thread_ts?: string }).thread_ts,
+          text: inThread ? CHAT_APOLOGY : buildChatErrorReply(prompt),
+          thread_ts: threadTs,
+          reply_broadcast: inThread,
         })
       },
     ),

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -68,14 +68,18 @@ async function loadConversationMessages(
     const res = await context.client.conversations.replies({
       channel: payload.channel,
       ts: threadTs,
-      limit: 20,
+      latest: payload.ts,
+      inclusive: true,
+      limit: 100,
     })
-    return buildChatMessages(
-      (res.messages as SlackReply[] | undefined) ?? null,
-      botUserId,
-      prompt,
-      payload.ts,
-    )
+    if (res.has_more) {
+      logger.warn('chat: thread exceeds the fetched window, older context is dropped', {
+        thread_ts: threadTs,
+        channel: payload.channel,
+      })
+    }
+    const recent = ((res.messages as SlackReply[] | undefined) ?? []).slice(-20)
+    return buildChatMessages(recent, botUserId, prompt, payload.ts)
   } catch (error) {
     logger.warn('chat: failed to load thread history', {
       error: error instanceof Error ? error.message : String(error),

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -1,11 +1,77 @@
-import { SlackApp, SlackOAuthApp } from 'slack-cloudflare-workers'
-import { LlamaChat } from '../ai/completions'
+import {
+  GenericMessageEvent,
+  SlackApp,
+  SlackAppContext,
+  SlackOAuthApp,
+} from 'slack-cloudflare-workers'
+import { ChatMessage, LlamaChat } from '../ai/completions'
+import { consoleLogger as logger } from '../lib/logger'
 import { NoBotMessage, safeMessage } from './util'
 
 const pattern = /^!chat\s(.*)/
 
 export function buildChatErrorReply(prompt: string): string {
   return `>${prompt}\n_応答に失敗しました。しばらくしてからもう一度試してください。_`
+}
+
+type SlackReply = {
+  user?: string
+  text?: string
+  subtype?: string
+}
+
+export function buildChatMessages(
+  replies: SlackReply[] | null,
+  botUserId: string,
+  currentPrompt: string,
+): ChatMessage[] {
+  const current: ChatMessage = { role: 'user', content: currentPrompt }
+  if (!replies || replies.length === 0) return [current]
+
+  const messages: ChatMessage[] = []
+  for (let i = 0; i < replies.length - 1; i++) {
+    const m = transformReply(replies[i], botUserId)
+    if (m) messages.push(m)
+  }
+  messages.push(current)
+  return messages
+}
+
+function transformReply(reply: SlackReply, botUserId: string): ChatMessage | null {
+  if (reply.subtype) return null
+  if (!reply.text) return null
+
+  const isBot = reply.user === botUserId
+  const content = isBot
+    ? reply.text.replace(/^>[^\n]*\n?/, '').trim()
+    : reply.text.replace(/^!chat\s+/, '').trim()
+  if (!content) return null
+  return { role: isBot ? 'assistant' : 'user', content }
+}
+
+async function loadConversationMessages(
+  context: SlackAppContext,
+  payload: GenericMessageEvent,
+  prompt: string,
+): Promise<ChatMessage[]> {
+  const threadTs = payload.thread_ts
+  if (!threadTs) return [{ role: 'user', content: prompt }]
+  const botUserId = context.botUserId
+  if (!botUserId) return [{ role: 'user', content: prompt }]
+
+  try {
+    const res = await context.client.conversations.replies({
+      channel: payload.channel,
+      ts: threadTs,
+      limit: 20,
+    })
+    return buildChatMessages((res.messages as SlackReply[] | undefined) ?? null, botUserId, prompt)
+  } catch (error) {
+    logger.warn('chat: failed to load thread history', {
+      error: error instanceof Error ? error.message : String(error),
+    })
+    return [{ role: 'user', content: prompt }]
+  }
 }
 
 export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat) {
@@ -16,10 +82,13 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
         if (!NoBotMessage(payload)) return
         const match = payload.text.match(pattern)
         if (!match || !match[1]) return
+        const prompt = match[1]
 
-        const message = await client.completions(match[1])
+        const messages = await loadConversationMessages(context, payload, prompt)
+        const reply = await client.chat(messages)
         await context.say({
-          text: `>${match[1]}\n${message}`,
+          text: `>${prompt}\n${reply}`,
+          thread_ts: payload.thread_ts,
         })
       },
       async ({ context, payload }) => {
@@ -27,7 +96,10 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
         const match = text?.match(pattern)
         const prompt = match?.[1]
         if (!prompt) return
-        await context.say({ text: buildChatErrorReply(prompt) })
+        await context.say({
+          text: buildChatErrorReply(prompt),
+          thread_ts: (payload as { thread_ts?: string }).thread_ts,
+        })
       },
     ),
   )

--- a/src/slack/util.ts
+++ b/src/slack/util.ts
@@ -28,7 +28,7 @@ export function DirectMention(
 
 export function NoBotMessage(
   payload: GenericMessageEvent | BotMessageEvent | FileShareMessageEvent | ThreadBroadcastMessageEvent,
-): boolean {
+): payload is GenericMessageEvent {
   return payload.subtype === undefined
 }
 


### PR DESCRIPTION
## Summary
- `!chat` をスレッド内で打つと `conversations.replies` で直近 20 件を取り、それを LlamaChat の messages として渡すようにした
- bot の返信は assistant 役 (引用行を剥がす)、他の発言は user 役 (`!chat ` prefix があれば剥がす)、subtype 付き / 空 text はスキップ
- bot の返信もスレッド内に投稿するように変更 (`thread_ts` 指定) → 次のターンも自然に履歴が繋がる
- `conversations.replies` が失敗した時は単発フォールバック + warn ログ
- `LlamaChat#chat(messages)` を追加 (既存 `completions(prompt)` は薄いラッパに)
- `NoBotMessage` を type predicate 化して narrowing 効くように

## Why
- 単発質問しかできなかったので、会話の流れを汲んだ応答ができなかった
- Workers AI の context window はゆとりがあり、直近 20 件分の messages を積んでも余裕

## Out of scope
- ストリーミング応答 (項目 3) は別 PR で
- DM/private channel での利用 (manifest に `groups:history` 等を増やせば対応できるが、現状の public channel 利用前提を維持)

## Test plan
- [x] `npx jest src/slack/__tests__/chat.test.ts` (12 件 pass)
- [x] `npx jest src/ai/__tests__/completions.test.ts` (7 件 pass)
- [x] `npm test` (全 62 件 pass)
- [x] `npx tsc --noEmit` (型エラーなし)
- [ ] merge → `npm run deploy`
- [ ] production でスレッド内 `!chat` を 2-3 ターン続けて、過去の文脈を踏まえた返信が来ることを確認
- [ ] スレッド外の単発 `!chat` が今まで通り動くことを確認