### PR TITLE
feat(chat): always reply in a thread and broadcast to the channel

### DIFF
--- a/src/slack/__tests__/chat.test.ts
+++ b/src/slack/__tests__/chat.test.ts
@@ -1,4 +1,4 @@
-import { buildChatErrorReply, buildChatMessages, CHAT_APOLOGY } from '../chat'
+import { buildChatMessages, CHAT_APOLOGY } from '../chat'
 
 const BOT_ID = 'UBOT'
 
@@ -124,25 +124,9 @@ describe('buildChatMessages', () => {
   })
 })
 
-describe('buildChatErrorReply', () => {
-  it('quotes the original prompt so the user knows which request failed', () => {
-    const reply = buildChatErrorReply('明日の天気は？')
-    expect(reply).toContain('>明日の天気は？')
-  })
-
-  it('includes a Japanese apology so the user sees something instead of silence', () => {
-    const reply = buildChatErrorReply('hello')
-    expect(reply).toMatch(/応答に失敗/)
-  })
-
-  it('returns a single string (not multi-line noise)', () => {
-    const reply = buildChatErrorReply('test')
-    // quote line + apology line — at most 2 lines, no trailing whitespace
-    expect(reply.split('\n').length).toBeLessThanOrEqual(2)
-    expect(reply).toBe(reply.trim())
-  })
-
-  it('embeds CHAT_APOLOGY so thread replies can reuse the same copy', () => {
-    expect(buildChatErrorReply('whatever')).toContain(CHAT_APOLOGY)
+describe('CHAT_APOLOGY', () => {
+  it('is a single-line apology that mentions the failure', () => {
+    expect(CHAT_APOLOGY).toMatch(/応答に失敗/)
+    expect(CHAT_APOLOGY.split('\n').length).toBe(1)
   })
 })

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -12,10 +12,6 @@ const pattern = /^!chat\s(.*)/
 
 export const CHAT_APOLOGY = '_応答に失敗しました。しばらくしてからもう一度試してください。_'
 
-export function buildChatErrorReply(prompt: string): string {
-  return `>${prompt}\n${CHAT_APOLOGY}`
-}
-
 type SlackReply = {
   user?: string
   text?: string
@@ -100,11 +96,10 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
 
         const messages = await loadConversationMessages(context, payload, prompt)
         const reply = await client.chat(messages)
-        const inThread = Boolean(payload.thread_ts)
         await context.say({
-          text: inThread ? reply : `>${prompt}\n${reply}`,
-          thread_ts: payload.thread_ts,
-          reply_broadcast: inThread,
+          text: reply,
+          thread_ts: payload.thread_ts ?? payload.ts,
+          reply_broadcast: true,
         })
       },
       async ({ context, payload }) => {
@@ -112,12 +107,11 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
         const match = text?.match(pattern)
         const prompt = match?.[1]?.trim()
         if (!prompt) return
-        const threadTs = (payload as { thread_ts?: string }).thread_ts
-        const inThread = Boolean(threadTs)
+        const p = payload as { thread_ts?: string; ts?: string }
         await context.say({
-          text: inThread ? CHAT_APOLOGY : buildChatErrorReply(prompt),
-          thread_ts: threadTs,
-          reply_broadcast: inThread,
+          text: CHAT_APOLOGY,
+          thread_ts: p.thread_ts ?? p.ts,
+          reply_broadcast: true,
         })
       },
     ),


### PR DESCRIPTION
## Summary
- `!chat` の bot 応答を **常に** 元メッセージへのスレッド返信にする (`thread_ts: payload.thread_ts ?? payload.ts`)
- 常に `reply_broadcast: true` で channel にも broadcast (Slack の「Also send to channel」相当)
- スレッド内/外で挙動が分岐していたのを廃止、引用 (`>${prompt}`) も廃止
- 引用付き fallback `buildChatErrorReply` は不要になったので削除、`CHAT_APOLOGY` のみ残す

## Why
直前 PR #49 では「スレッド内のみ thread reply」「スレッド外は通常メッセージ」と分岐していたが、スレッド外で `!chat` を打つと従来と見た目が変わらず、変化を実感しにくかった。常に thread reply 化 + broadcast で `!chat` の応答を視覚的に明確化する。

## Test plan
- [x] `npm test` (全 63 件 pass)
- [x] `npx tsc --noEmit`
- [ ] merge → `npm run deploy`
- [ ] スレッド外で `!chat foo` → 元メッセージのスレッドに bot 応答が入り、channel にも broadcast されることを確認
- [ ] スレッド内で `!chat foo` → そのスレッド内に bot 応答が入る (元の thread_ts が継続) ことを確認