### PR TITLE
fix(chat): use flat string parameter for choose_random tool

### DIFF
--- a/src/ai/__tests__/tools.test.ts
+++ b/src/ai/__tests__/tools.test.ts
@@ -16,13 +16,32 @@ describe('chooseRandom', () => {
 })
 
 describe('executeTool', () => {
-  it('dispatches choose_random to chooseRandom', () => {
-    expect(executeTool({ name: 'choose_random', arguments: { items: ['x'] } })).toBe('x')
+  it('dispatches choose_random with a CSV string', () => {
+    expect(executeTool({ name: 'choose_random', arguments: { items: 'only' } })).toBe('only')
   })
 
-  it('coerces non-string items via String()', () => {
-    const result = executeTool({ name: 'choose_random', arguments: { items: [1, 'two'] } })
-    expect(['1', 'two']).toContain(result)
+  it('splits the CSV string and trims whitespace', () => {
+    const result = executeTool({
+      name: 'choose_random',
+      arguments: { items: ' カレー , ラーメン , うどん ' },
+    })
+    expect(['カレー', 'ラーメン', 'うどん']).toContain(result)
+  })
+
+  it('also accepts a Japanese full-width comma', () => {
+    const result = executeTool({
+      name: 'choose_random',
+      arguments: { items: 'a、b、c' },
+    })
+    expect(['a', 'b', 'c']).toContain(result)
+  })
+
+  it('falls back to a string array if the model sent an array anyway', () => {
+    const result = executeTool({
+      name: 'choose_random',
+      arguments: { items: ['x', 'y'] },
+    })
+    expect(['x', 'y']).toContain(result)
   })
 
   it('returns a fallback when items is missing', () => {
@@ -35,12 +54,12 @@ describe('executeTool', () => {
 })
 
 describe('TOOLS', () => {
-  it('exposes choose_random with an items array parameter', () => {
+  it('exposes choose_random with a string items parameter (Workers AI schema only allows flat types)', () => {
     const t = TOOLS.find((tool) => tool.name === 'choose_random')
     expect(t).toBeDefined()
     expect(t?.parameters).toMatchObject({
       type: 'object',
-      properties: { items: { type: 'array' } },
+      properties: { items: { type: 'string' } },
       required: ['items'],
     })
   })

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -20,14 +20,13 @@ export const TOOLS: Tool[] = [
   {
     name: 'choose_random',
     description:
-      'ユーザーが複数の選択肢から 1 つ選ぶよう求めたときに使う。各選択肢を items 配列に入れて渡すと、その中からランダムに 1 つ返す。',
+      'ユーザーが複数の選択肢から 1 つ選ぶよう求めたときに使う。選択肢をカンマ区切りで items に入れて渡すと、その中からランダムに 1 つ返す。',
     parameters: {
       type: 'object',
       properties: {
         items: {
-          type: 'array',
-          items: { type: 'string' },
-          description: '選択肢のリスト',
+          type: 'string',
+          description: 'カンマ区切りの選択肢 (例: "カレー,ラーメン,うどん")',
         },
       },
       required: ['items'],
@@ -39,10 +38,23 @@ export function executeTool(call: ToolCall): string {
   switch (call.name) {
     case 'choose_random': {
       const raw = call.arguments.items
-      if (!Array.isArray(raw)) return NO_CANDIDATES
-      return chooseRandom(raw.map((v) => String(v)))
+      const items = parseCsvItems(raw)
+      return chooseRandom(items)
     }
     default:
       return `unknown tool: ${call.name}`
   }
+}
+
+function parseCsvItems(raw: unknown): string[] {
+  if (typeof raw === 'string') {
+    return raw
+      .split(/[,、]/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+  }
+  if (Array.isArray(raw)) {
+    return raw.map((v) => String(v).trim()).filter((s) => s.length > 0)
+  }
+  return []
 }


### PR DESCRIPTION
## Summary
PR #52 (Phase 1) で導入した \`choose_random\` tool が production で \`AiError 8001: Invalid input\` を返していた hotfix。

- Workers AI の Llama 4 Scout は tool schema の \`properties\` を \`{ type: string; description: string }\` の flat 形式しか許容しない (前回 \`as unknown as\` キャストで隠れていた事実)
- 以前: \`type: 'array', items: { type: 'string' }\` → AI 側でリクエスト時点で reject → handler が apology を返す
- 修正: \`items\` を \`type: 'string'\` (カンマ区切り文字列) に。\`executeTool\` 側で split。全角カンマ \`、\` も許容
- 念のため、model が誤って array を渡してきた場合のフォールバックも保持

## Test plan
- [x] \`npm test\` (全 78 件 pass)
- [x] \`npx tsc --noEmit\`
- [ ] merge → \`npm run deploy\`
- [ ] production で \`@jpi カレーかラーメンかうどんか選んで\` → AI が choose_random を呼んで返答することを確認