### PR TITLE
fix(chat): use @cloudflare/ai-utils runWithTools for function calling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "slackbot",
             "version": "2024.8.2",
             "dependencies": {
+                "@cloudflare/ai-utils": "^1.0.1",
                 "jsx-slack": "^6.1.1",
                 "semver": ">=7.5.2",
                 "slack-cloudflare-workers": "^1.0.0"
@@ -643,6 +644,16 @@
             "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
             "dev": true
+        },
+        "node_modules/@cloudflare/ai-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@cloudflare/ai-utils/-/ai-utils-1.0.1.tgz",
+            "integrity": "sha512-gmn16AvVqtMLcaBYvPkwEWui39E4hlcFPqXuVamKbGleIDO6hVpvAy3KCvbnoPVT7KqRcfdLLpHRIBQDwI9tWQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "yaml": "^2.4.5",
+                "zod": "^3.23.8"
+            }
         },
         "node_modules/@cloudflare/kv-asset-handler": {
             "version": "0.4.2",
@@ -5306,6 +5317,21 @@
                 "node": ">=10"
             }
         },
+        "node_modules/yaml": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
+            }
+        },
         "node_modules/yargs": {
             "version": "17.7.2",
             "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
@@ -5368,6 +5394,15 @@
             "dependencies": {
                 "@poppinss/exception": "^1.2.2",
                 "error-stack-parser-es": "^1.0.5"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "fix:prettier": "prettier --write src/**/**.ts"
     },
     "dependencies": {
+        "@cloudflare/ai-utils": "^1.0.1",
         "jsx-slack": "^6.1.1",
         "semver": ">=7.5.2",
         "slack-cloudflare-workers": "^1.0.0"

--- a/src/ai/__tests__/completions.test.ts
+++ b/src/ai/__tests__/completions.test.ts
@@ -1,3 +1,7 @@
+// @cloudflare/ai-utils ships as ESM and Jest cannot parse it directly.
+// chatWithTools just delegates to runWithTools, so a no-op stub is enough.
+jest.mock('@cloudflare/ai-utils', () => ({ runWithTools: jest.fn() }))
+
 import { LlamaChat } from '../completions'
 
 const MODEL_ID = '@cf/meta/llama-4-scout-17b-16e-instruct'
@@ -75,59 +79,6 @@ describe('LlamaChat', () => {
     })
   })
 
-  describe('chatWithTools', () => {
-    const tools = [
-      {
-        name: 'pick',
-        description: 'pick',
-        parameters: { type: 'object', properties: {}, required: [] },
-      },
-    ]
-
-    it('passes tools array through to AI.run', async () => {
-      const ai = fakeAi(async () => ({ response: 'done', tool_calls: [] }))
-      const client = new LlamaChat(ai)
-      await client.chatWithTools([{ role: 'user', content: 'q' }], tools)
-
-      const [, body] = ai.run.mock.calls[0]
-      expect(body.tools).toBe(tools)
-    })
-
-    it('returns text and empty toolCalls when no tools were called', async () => {
-      const ai = fakeAi(async () => ({ response: '  hello  ' }))
-      const client = new LlamaChat(ai)
-      const result = await client.chatWithTools([{ role: 'user', content: 'q' }], tools)
-      expect(result).toEqual({ text: 'hello', toolCalls: [] })
-    })
-
-    it('normalizes tool_calls with object arguments', async () => {
-      const ai = fakeAi(async () => ({
-        response: '',
-        tool_calls: [{ name: 'pick', arguments: { items: ['a', 'b'] } }],
-      }))
-      const client = new LlamaChat(ai)
-      const result = await client.chatWithTools([{ role: 'user', content: 'q' }], tools)
-      expect(result.toolCalls).toEqual([{ name: 'pick', arguments: { items: ['a', 'b'] } }])
-    })
-
-    it('normalizes tool_calls when arguments is a JSON string', async () => {
-      const ai = fakeAi(async () => ({
-        response: '',
-        tool_calls: [{ name: 'pick', arguments: '{"items":["x"]}' }],
-      }))
-      const client = new LlamaChat(ai)
-      const result = await client.chatWithTools([{ role: 'user', content: 'q' }], tools)
-      expect(result.toolCalls).toEqual([{ name: 'pick', arguments: { items: ['x'] } }])
-    })
-
-    it('drops malformed tool_calls entries instead of throwing', async () => {
-      const ai = fakeAi(async () => ({
-        response: '',
-        tool_calls: [{ name: 'pick', arguments: { ok: true } }, null, { arguments: {} }],
-      }))
-      const client = new LlamaChat(ai)
-      const result = await client.chatWithTools([{ role: 'user', content: 'q' }], tools)
-      expect(result.toolCalls).toEqual([{ name: 'pick', arguments: { ok: true } }])
-    })
-  })
+  // chatWithTools delegates to @cloudflare/ai-utils' runWithTools; behaviour is
+  // exercised in production rather than mocked here.
 })

--- a/src/ai/__tests__/tools.test.ts
+++ b/src/ai/__tests__/tools.test.ts
@@ -1,4 +1,4 @@
-import { chooseRandom, executeTool, TOOLS } from '../tools'
+import { chooseRandom, TOOLS } from '../tools'
 
 describe('chooseRandom', () => {
   it('returns the only item when the list has length 1', () => {
@@ -15,46 +15,33 @@ describe('chooseRandom', () => {
   })
 })
 
-describe('executeTool', () => {
-  it('dispatches choose_random with a CSV string', () => {
-    expect(executeTool({ name: 'choose_random', arguments: { items: 'only' } })).toBe('only')
-  })
+describe('choose_random tool', () => {
+  const tool = TOOLS.find((t) => t.name === 'choose_random')!
+  const callFn = (args: unknown) => tool.function!(args as { items?: unknown })
 
-  it('splits the CSV string and trims whitespace', () => {
-    const result = executeTool({
-      name: 'choose_random',
-      arguments: { items: ' カレー , ラーメン , うどん ' },
-    })
+  it('splits a CSV string and returns one item', async () => {
+    const result = await callFn({ items: 'カレー,ラーメン,うどん' })
     expect(['カレー', 'ラーメン', 'うどん']).toContain(result)
   })
 
-  it('also accepts a Japanese full-width comma', () => {
-    const result = executeTool({
-      name: 'choose_random',
-      arguments: { items: 'a、b、c' },
-    })
+  it('also accepts Japanese full-width comma', async () => {
+    const result = await callFn({ items: 'a、b、c' })
     expect(['a', 'b', 'c']).toContain(result)
   })
 
-  it('falls back to a string array if the model sent an array anyway', () => {
-    const result = executeTool({
-      name: 'choose_random',
-      arguments: { items: ['x', 'y'] },
-    })
+  it('falls back to a string array if items is sent as an array', async () => {
+    const result = await callFn({ items: ['x', 'y'] })
     expect(['x', 'y']).toContain(result)
   })
 
-  it('returns a fallback when items is missing', () => {
-    expect(executeTool({ name: 'choose_random', arguments: {} })).toMatch(/候補/)
-  })
-
-  it('returns an error string for unknown tools', () => {
-    expect(executeTool({ name: 'wat', arguments: {} })).toMatch(/unknown/)
+  it('returns the no-candidates fallback when items is missing', async () => {
+    const result = await callFn({})
+    expect(result).toMatch(/候補/)
   })
 })
 
 describe('TOOLS', () => {
-  it('exposes choose_random with a string items parameter (Workers AI schema only allows flat types)', () => {
+  it('exposes choose_random with a flat string parameter (Workers AI flat schema)', () => {
     const t = TOOLS.find((tool) => tool.name === 'choose_random')
     expect(t).toBeDefined()
     expect(t?.parameters).toMatchObject({
@@ -62,5 +49,11 @@ describe('TOOLS', () => {
       properties: { items: { type: 'string' } },
       required: ['items'],
     })
+  })
+
+  it('attaches a callable function to each tool (runWithTools requires it)', () => {
+    for (const tool of TOOLS) {
+      expect(typeof tool.function).toBe('function')
+    }
   })
 })

--- a/src/ai/completions.ts
+++ b/src/ai/completions.ts
@@ -1,5 +1,6 @@
+import { runWithTools } from '@cloudflare/ai-utils'
 import { Ai } from '@cloudflare/workers-types'
-import { Tool, ToolCall } from './tools'
+import { Tool } from './tools'
 
 const MODEL = '@cf/meta/llama-4-scout-17b-16e-instruct'
 const SYSTEM_PROMPT =
@@ -7,16 +8,8 @@ const SYSTEM_PROMPT =
 const MAX_TOKENS = 512
 
 export type ChatMessage = {
-  role: 'user' | 'assistant' | 'tool'
+  role: 'system' | 'user' | 'assistant' | 'tool'
   content: string
-  tool_calls?: unknown[]
-  tool_call_id?: string
-  name?: string
-}
-
-export type ChatResult = {
-  text: string
-  toolCalls: ToolCall[]
 }
 
 export class LlamaChat {
@@ -35,17 +28,12 @@ export class LlamaChat {
     return extractText(result)
   }
 
-  async chatWithTools(messages: ChatMessage[], tools: Tool[]): Promise<ChatResult> {
-    const runner = this.ai as unknown as {
-      run: (model: string, body: unknown) => Promise<unknown>
-    }
-    const result = await runner.run(MODEL, {
+  async chatWithTools(messages: ChatMessage[], tools: Tool[]): Promise<string> {
+    const result = await runWithTools(this.ai, MODEL, {
       messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...messages],
       tools,
-      max_tokens: MAX_TOKENS,
-      temperature: 0.8,
     })
-    return extractChatResult(result)
+    return extractText(result)
   }
 }
 
@@ -60,36 +48,6 @@ function extractText(result: unknown): string {
     }
   }
   throw new Error(`Unexpected Workers AI response shape: ${safeStringify(result)}`)
-}
-
-function extractChatResult(result: unknown): ChatResult {
-  if (typeof result === 'string') return { text: result.trim(), toolCalls: [] }
-  if (!result || typeof result !== 'object') {
-    throw new Error(`Unexpected Workers AI response shape: ${safeStringify(result)}`)
-  }
-  const r = result as { response?: unknown; tool_calls?: unknown }
-  const text = typeof r.response === 'string' ? r.response.trim() : ''
-  const toolCalls = Array.isArray(r.tool_calls)
-    ? r.tool_calls.map(normalizeToolCall).filter((c): c is ToolCall => c !== null)
-    : []
-  return { text, toolCalls }
-}
-
-function normalizeToolCall(raw: unknown): ToolCall | null {
-  if (!raw || typeof raw !== 'object') return null
-  const obj = raw as { name?: unknown; arguments?: unknown }
-  if (typeof obj.name !== 'string') return null
-  let args: Record<string, unknown> = {}
-  if (typeof obj.arguments === 'string') {
-    try {
-      args = JSON.parse(obj.arguments)
-    } catch {
-      args = {}
-    }
-  } else if (obj.arguments && typeof obj.arguments === 'object') {
-    args = obj.arguments as Record<string, unknown>
-  }
-  return { name: obj.name, arguments: args }
 }
 
 function safeStringify(value: unknown): string {

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1,19 +1,25 @@
-export type Tool = {
-  name: string
-  description: string
-  parameters: object
-}
+import type { AiTextGenerationToolInputWithFunction } from '@cloudflare/ai-utils'
 
-export type ToolCall = {
-  name: string
-  arguments: Record<string, unknown>
-}
+export type Tool = AiTextGenerationToolInputWithFunction
 
 const NO_CANDIDATES = '候補がありません'
 
 export function chooseRandom(items: string[]): string {
   if (items.length === 0) return NO_CANDIDATES
   return items[Math.floor(Math.random() * items.length)]
+}
+
+function parseCsvItems(raw: unknown): string[] {
+  if (typeof raw === 'string') {
+    return raw
+      .split(/[,、]/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+  }
+  if (Array.isArray(raw)) {
+    return raw.map((v) => String(v).trim()).filter((s) => s.length > 0)
+  }
+  return []
 }
 
 export const TOOLS: Tool[] = [
@@ -31,30 +37,8 @@ export const TOOLS: Tool[] = [
       },
       required: ['items'],
     },
+    function: async (args: { items?: unknown }) => {
+      return chooseRandom(parseCsvItems(args?.items))
+    },
   },
 ]
-
-export function executeTool(call: ToolCall): string {
-  switch (call.name) {
-    case 'choose_random': {
-      const raw = call.arguments.items
-      const items = parseCsvItems(raw)
-      return chooseRandom(items)
-    }
-    default:
-      return `unknown tool: ${call.name}`
-  }
-}
-
-function parseCsvItems(raw: unknown): string[] {
-  if (typeof raw === 'string') {
-    return raw
-      .split(/[,、]/)
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0)
-  }
-  if (Array.isArray(raw)) {
-    return raw.map((v) => String(v).trim()).filter((s) => s.length > 0)
-  }
-  return []
-}

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -5,14 +5,12 @@ import {
   SlackOAuthApp,
 } from 'slack-cloudflare-workers'
 import { ChatMessage, LlamaChat } from '../ai/completions'
-import { executeTool, TOOLS } from '../ai/tools'
+import { TOOLS } from '../ai/tools'
 import { consoleLogger as logger } from '../lib/logger'
 import { DirectMention, formatError, NoBotMessage, safeMessage } from './util'
 
 const prefixPattern = /^!chat\s(.*)/
 const mentionPrefix = /^<@[^>]+>\s*/
-
-const MAX_TOOL_TURNS = 3
 
 export const CHAT_APOLOGY = '_応答に失敗しました。しばらくしてからもう一度試してください。_'
 
@@ -82,28 +80,6 @@ async function fetchRecentThreadReplies(
   }
 }
 
-async function runToolLoop(
-  client: LlamaChat,
-  initialMessages: ChatMessage[],
-): Promise<string> {
-  let messages = initialMessages
-  for (let turn = 0; turn < MAX_TOOL_TURNS; turn++) {
-    const result = await client.chatWithTools(messages, TOOLS)
-    if (result.toolCalls.length === 0) return result.text
-    messages = [
-      ...messages,
-      { role: 'assistant', content: result.text, tool_calls: result.toolCalls },
-      ...result.toolCalls.map((call) => ({
-        role: 'tool' as const,
-        content: executeTool(call),
-        name: call.name,
-      })),
-    ]
-  }
-  logger.warn('chat: tool turn limit reached', { turns: MAX_TOOL_TURNS })
-  return ''
-}
-
 export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat) {
   app.message(
     /.*/,
@@ -139,7 +115,7 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
           : [{ role: 'user', content: prompt }]
 
       try {
-        const reply = await runToolLoop(client, initialMessages)
+        const reply = await client.chatWithTools(initialMessages, TOOLS)
         await context.say({
           text: reply || CHAT_APOLOGY,
           thread_ts: threadTs,


### PR DESCRIPTION
## Summary
Phase 1 (PR #52) で導入した tool calling が production で \`AiError 8001\` 連発だった件の根本対応。

- Llama 4 Scout の Traditional function calling (\`env.AI.run\` に直接 \`tools\` を渡す) は capability 上 \"Yes\" だが実態 \"No\"。docs にも実例が無い (Hermes-2-Pro のみ)
- 公式推奨の Embedded function calling = \`@cloudflare/ai-utils\` の \`runWithTools\` 経由に切り替え
- 各 tool に \`function\` callback を持たせ、runWithTools が内部でループ
- 外部の tool loop (runToolLoop, executeTool dispatcher, MAX_TOOL_TURNS, ToolCall 正規化, ChatResult 型) を全削除 → コードベース -190 行
- \`chatWithTools\` は薄いラッパに
- Jest は ai-utils の ESM を parse できないため、completions.test.ts は \`jest.mock('@cloudflare/ai-utils')\` で stub

## Test plan
- [x] \`npm test\` (全 72 件 pass)
- [x] \`npx tsc --noEmit\`
- [ ] merge → \`npm run deploy\`
- [ ] production で \`@jpi カレーかラーメンかうどんか選んで\` → AI が choose_random を呼んで 1 つ返すことを確認

## Note
- runWithTools が Llama 4 Scout で実際に動くかは production 確認が必要
- 動かなければモデル切り替え (Hermes-2-Pro) or rollback を再検討