### PR TITLE
feat(chat): add search_image tool (Phase 2 of 3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,12 +51,13 @@ export default {
     })
     const llama = new LlamaChat(env.AI)
 
-    keshite(app)
-    jpi(app, {
+    const jpiConfig = {
       imageEndpoint: env.JPI_IMAGE_ENDPOINT,
       signingSecret: env.JPI_SIGNING_SECRET,
-    })
-    chat(app, llama)
+    }
+    keshite(app)
+    jpi(app, jpiConfig)
+    chat(app, llama, jpiConfig)
     ping(app)
 
     app.event("message", async({}) => {})

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -4,9 +4,12 @@ import {
   SlackAppContext,
   SlackOAuthApp,
 } from 'slack-cloudflare-workers'
+import { JSXSlack } from 'jsx-slack'
 import { ChatMessage, LlamaChat } from '../ai/completions'
-import { TOOLS } from '../ai/tools'
+import { Tool, TOOLS } from '../ai/tools'
+import { buildJpiImageUrl, JpiConfig } from '../jpi/url_builder'
 import { consoleLogger as logger } from '../lib/logger'
+import { jpiBlocks } from './views/jpi'
 import { DirectMention, formatError, NoBotMessage, safeMessage } from './util'
 
 const prefixPattern = /^!chat\s(.*)/
@@ -80,7 +83,55 @@ async function fetchRecentThreadReplies(
   }
 }
 
-export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat) {
+type SayFn = (args: {
+  text?: string
+  blocks?: unknown
+  link_names?: boolean
+  thread_ts?: string
+  reply_broadcast?: boolean
+}) => Promise<unknown>
+
+function buildSearchImageTool(say: SayFn, threadTs: string, jpiConfig: JpiConfig): Tool {
+  return {
+    name: 'search_image',
+    description:
+      'ユーザーがキーワードに合う画像を求めたときに使う。Google Custom Search 経由で画像を 1 枚取得し、Slack のスレッドに直接投稿する。投稿は副作用として行うので、最終応答では「画像を出しました」など短く触れるだけで良い。',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: '画像を検索するキーワード (短い名詞や名詞句が望ましい)',
+        },
+      },
+      required: ['query'],
+    },
+    function: async (args: { query?: unknown }) => {
+      const query = typeof args?.query === 'string' ? args.query.trim() : ''
+      if (!query) return '検索キーワードが空でした'
+      try {
+        const imageUrl = await buildJpiImageUrl(jpiConfig, query)
+        await say({
+          text: query,
+          blocks: JSXSlack(jpiBlocks({ text: query, url: imageUrl })),
+          link_names: false,
+          thread_ts: threadTs,
+          reply_broadcast: true,
+        })
+        return `「${query}」の画像をスレッドに投稿しました`
+      } catch (error) {
+        logger.warn('chat: search_image tool failed', { error: formatError(error) })
+        return `「${query}」の画像取得に失敗しました`
+      }
+    },
+  }
+}
+
+export function chat(
+  app: SlackApp<any> | SlackOAuthApp<any>,
+  client: LlamaChat,
+  jpiConfig: JpiConfig,
+) {
   app.message(
     /.*/,
     safeMessage(async ({ context, payload }) => {
@@ -114,8 +165,13 @@ export function chat(app: SlackApp<any> | SlackOAuthApp<any>, client: LlamaChat)
           ? buildChatMessages(replies, botUserId, prompt, payload.ts)
           : [{ role: 'user', content: prompt }]
 
+      const tools: Tool[] = [
+        ...TOOLS,
+        buildSearchImageTool(context.say as SayFn, threadTs, jpiConfig),
+      ]
+
       try {
-        const reply = await client.chatWithTools(initialMessages, TOOLS)
+        const reply = await client.chatWithTools(initialMessages, tools)
         await context.say({
           text: reply || CHAT_APOLOGY,
           thread_ts: threadTs,


### PR DESCRIPTION
## Summary (Phase 2 of 3)
- 既存の \`buildJpiImageUrl\` + \`jpiBlocks\` の経路をそのまま \`search_image\` tool として AI から呼べるように
- AI が tool を呼ぶ → 画像 blocks を **副作用としてスレッドに直接投稿** + broadcast → tool 戻り値は短い summary string
- AI は戻り値を踏まえて最終応答 text を生成 (「画像を出しました」程度)
- \`!jpi <keyword>\` prefix handler は維持 (即時性・タイプ少なめ需要)

## Design notes
- \`search_image\` は context-aware (\`say\`, \`thread_ts\`, \`jpiConfig\` が必要) なので、static \`TOOLS\` export ではなく \`buildSearchImageTool(say, threadTs, jpiConfig)\` で handler 起動ごとに組み立てる
- \`say\` は narrow \`SayFn\` 型で受けて、フル \`SlackAppContext\` の引き回しを回避
- \`index.ts\` で \`jpiConfig\` を hoist して \`!jpi\` handler / chat tool で共有

## Test plan
- [x] \`npm test\` (全 72 件 pass)
- [x] \`npx tsc --noEmit\`
- [ ] merge → \`npm run deploy\`
- [ ] production で \`@jpi 猫の画像探して\` → AI が \`search_image\` を呼んで画像 blocks がスレッドに投稿される + AI の最終応答 text も追加 (2 メッセージ)
- [ ] \`!jpi neko\` (既存 prefix) は今まで通り 1 メッセージで画像表示

## Phase 3 (別 PR)
- \`delete_message\` tool 化 + \`keshite\` / \`ping\` handler の廃止