### PR TITLE
fix(chat): self-rolled tool loop (ai-utils can't read Scout's tool_calls)

### DIFF
--- a/src/ai/__tests__/completions.test.ts
+++ b/src/ai/__tests__/completions.test.ts
@@ -1,7 +1,3 @@
-// @cloudflare/ai-utils ships as ESM and Jest cannot parse it directly.
-// chatWithTools just delegates to runWithTools, so a no-op stub is enough.
-jest.mock('@cloudflare/ai-utils', () => ({ runWithTools: jest.fn() }))
-
 import { LlamaChat } from '../completions'
 
 const MODEL_ID = '@cf/meta/llama-4-scout-17b-16e-instruct'

--- a/src/ai/completions.ts
+++ b/src/ai/completions.ts
@@ -1,10 +1,14 @@
-import { runWithTools } from '@cloudflare/ai-utils'
 import { Ai } from '@cloudflare/workers-types'
 import { Tool } from './tools'
 
 const MODEL = '@cf/meta/llama-4-scout-17b-16e-instruct'
-const SYSTEM_PROMPT =
-  'あなたはチャットボットです。短い返答が望ましいです。また、特に指示が無い場合は日本語で応答してください'
+const SYSTEM_PROMPT = [
+  'あなたはチャットボットです。短い返答が望ましいです。特に指示が無い場合は日本語で応答してください。',
+  '',
+  '利用可能なツールがあれば必ず積極的に使ってください。とくに以下を厳守してください:',
+  '- ユーザーが「画像」「絵」「写真」を求めたら、必ず search_image ツールを呼ぶこと。架空の結果 (例: 「画像見つかりました」だけ返す) は絶対にしてはいけません。',
+  '- ユーザーが選択肢から 1 つ選ぶよう求めたら、必ず choose_random ツールを呼ぶこと。',
+].join('\n')
 const MAX_TOKENS = 512
 
 export type ChatMessage = {
@@ -29,11 +33,40 @@ export class LlamaChat {
   }
 
   async chatWithTools(messages: ChatMessage[], tools: Tool[]): Promise<string> {
-    const result = await runWithTools(this.ai, MODEL, {
+    // Workers AI's Llama 4 Scout requires tools wrapped as
+    // { type: 'function', function: { name, description, parameters } }
+    // and returns tool_calls in the same wrapped shape — neither shape is
+    // handled by @cloudflare/ai-utils' runWithTools, so we drive the loop
+    // ourselves.
+    const wrappedTools = tools.map((t) => ({
+      type: 'function' as const,
+      function: { name: t.name, description: t.description, parameters: t.parameters },
+    }))
+    const runner = this.ai as unknown as {
+      run: (model: string, body: unknown) => Promise<unknown>
+    }
+    const raw = await runner.run(MODEL, {
       messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...messages],
-      tools,
+      tools: wrappedTools,
+      max_tokens: MAX_TOKENS,
+      temperature: 0.8,
     })
-    return extractText(result)
+    const result = raw as { response?: unknown; tool_calls?: unknown }
+    const toolCalls = parseToolCalls(result.tool_calls)
+    if (toolCalls.length === 0) return extractText(raw)
+
+    // A tool was invoked — return the tool's own output verbatim and skip the
+    // follow-up "AI commentary" turn. Tools that already posted to Slack as a
+    // side effect (e.g. search_image) return an empty string so the caller
+    // posts nothing additional.
+    const outputs: string[] = []
+    for (const call of toolCalls) {
+      const tool = tools.find((t) => t.name === call.name)
+      const fn = tool?.function
+      const out = fn ? await fn(call.arguments) : `unknown tool: ${call.name}`
+      if (out) outputs.push(out)
+    }
+    return outputs.join('\n')
   }
 }
 
@@ -56,4 +89,34 @@ function safeStringify(value: unknown): string {
   } catch {
     return String(value).slice(0, 200)
   }
+}
+
+type ParsedToolCall = { id?: string; name: string; arguments: Record<string, unknown> }
+
+// Workers AI's Llama 4 Scout returns tool_calls in OpenAI's wrapped shape:
+//   { id, type: 'function', function: { name, arguments } }
+// where arguments is sometimes a JSON-encoded string. Accept the flat shape
+// too (in case Hermes or any future model returns it directly).
+function parseToolCalls(raw: unknown): ParsedToolCall[] {
+  if (!Array.isArray(raw)) return []
+  return raw.flatMap((entry): ParsedToolCall[] => {
+    if (!entry || typeof entry !== 'object') return []
+    const e = entry as { id?: unknown; function?: unknown; name?: unknown; arguments?: unknown }
+    const fn = (e.function && typeof e.function === 'object' ? e.function : e) as {
+      name?: unknown
+      arguments?: unknown
+    }
+    if (typeof fn.name !== 'string') return []
+    let args: Record<string, unknown> = {}
+    if (typeof fn.arguments === 'string') {
+      try {
+        args = JSON.parse(fn.arguments)
+      } catch {
+        args = {}
+      }
+    } else if (fn.arguments && typeof fn.arguments === 'object') {
+      args = fn.arguments as Record<string, unknown>
+    }
+    return [{ id: typeof e.id === 'string' ? e.id : undefined, name: fn.name, arguments: args }]
+  })
 }

--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -95,20 +95,20 @@ function buildSearchImageTool(say: SayFn, threadTs: string, jpiConfig: JpiConfig
   return {
     name: 'search_image',
     description:
-      'ユーザーがキーワードに合う画像を求めたときに使う。Google Custom Search 経由で画像を 1 枚取得し、Slack のスレッドに直接投稿する。投稿は副作用として行うので、最終応答では「画像を出しました」など短く触れるだけで良い。',
+      'ユーザーが「画像」「絵」「写真」を求めたら必ずこの tool を呼ぶ。架空の応答 (例:「画像見つかりました」とだけ返す) はしてはいけない。tool が画像を Slack に直接投稿するので、最終応答は「どうぞ」のような短い一言で良い。',
     parameters: {
       type: 'object',
       properties: {
         query: {
           type: 'string',
-          description: '画像を検索するキーワード (短い名詞や名詞句が望ましい)',
+          description: '画像を検索するキーワード (短い名詞句、例: "猫", "東京タワー")',
         },
       },
       required: ['query'],
     },
     function: async (args: { query?: unknown }) => {
       const query = typeof args?.query === 'string' ? args.query.trim() : ''
-      if (!query) return '検索キーワードが空でした'
+      if (!query) return ''
       try {
         const imageUrl = await buildJpiImageUrl(jpiConfig, query)
         await say({
@@ -118,7 +118,9 @@ function buildSearchImageTool(say: SayFn, threadTs: string, jpiConfig: JpiConfig
           thread_ts: threadTs,
           reply_broadcast: true,
         })
-        return `「${query}」の画像をスレッドに投稿しました`
+        // Empty return → the chat handler suppresses the AI follow-up text,
+        // so the only message in the thread is the image block we just posted.
+        return ''
       } catch (error) {
         logger.warn('chat: search_image tool failed', { error: formatError(error) })
         return `「${query}」の画像取得に失敗しました`
@@ -172,8 +174,11 @@ export function chat(
 
       try {
         const reply = await client.chatWithTools(initialMessages, tools)
+        // Empty reply means a tool already posted to Slack as a side effect
+        // (e.g. search_image) — don't echo an extra message.
+        if (!reply) return
         await context.say({
-          text: reply || CHAT_APOLOGY,
+          text: reply,
           thread_ts: threadTs,
           reply_broadcast: true,
         })


### PR DESCRIPTION
## Background
PR #55 をマージして deploy → production で \`@jpi 猫の画像探して\` が "見つかりました!" の text だけで画像が出ない問題が発生。verbose ログ で原因確認:

\`\`\`
(error) ERROR: Tool undefined not found, maybe AI hallucinated
\`\`\`

- Llama 4 Scout は tool_calls を OpenAI 互換の **wrap 形式** で返す: \`{ id, type: 'function', function: { name, arguments } }\`
- \`@cloudflare/ai-utils\` の \`runWithTools\` は flat 形式 (\`toolCall.name\`) しか読まないため、\`name\` が undefined になり「hallucinated」と判定して tool 実行をスキップ
- ai-utils の bug 相当

## Fix
- \`runWithTools\` を捨てて、self-rolled な tool loop を \`LlamaChat.chatWithTools\` に書く
- AI への送信時は wrap 形式 (\`{ type: 'function', function: {...} }\`) を維持 (Scout はこの形を要求)
- レスポンスは wrap/flat 両対応の \`parseToolCalls\` でパース
- **tool が呼ばれた場合、AI の最終応答 turn は skip** し、tool 戻り値をそのまま reply にする
  - search_image: 画像投稿は副作用、戻り値は空文字 → handler 側で投稿スキップ
  - choose_random: 戻り値「カレー」を Slack に直接投稿
- system prompt に「画像/絵/写真 → search_image」「選択 → choose_random」を厳守させる強い指示
- \`@cloudflare/ai-utils\` の import と jest mock を削除

## Verified
- production deploy 済 (\`Version ID: 7d59311f\`)
- \`@jpi 猫の画像探して\` → 画像のみが thread に投稿される (text コメントなし) を確認済み

## Test plan
- [x] \`npm test\` (全 72 件 pass)
- [x] \`npx tsc --noEmit\`
- [x] production で動作確認済み