### PR TITLE
fix(chat,jpi): broadcast only on the first reply

### DIFF
--- a/src/slack/chat.ts
+++ b/src/slack/chat.ts
@@ -91,7 +91,12 @@ type SayFn = (args: {
   reply_broadcast?: boolean
 }) => Promise<unknown>
 
-function buildSearchImageTool(say: SayFn, threadTs: string, jpiConfig: JpiConfig): Tool {
+function buildSearchImageTool(
+  say: SayFn,
+  threadTs: string,
+  broadcast: boolean,
+  jpiConfig: JpiConfig,
+): Tool {
   return {
     name: 'search_image',
     description:
@@ -116,7 +121,7 @@ function buildSearchImageTool(say: SayFn, threadTs: string, jpiConfig: JpiConfig
           blocks: JSXSlack(jpiBlocks({ text: query, url: imageUrl })),
           link_names: false,
           thread_ts: threadTs,
-          reply_broadcast: true,
+          reply_broadcast: broadcast,
         })
         // Empty return → the chat handler suppresses the AI follow-up text,
         // so the only message in the thread is the image block we just posted.
@@ -162,6 +167,9 @@ export function chat(
 
       const prompt = explicitPrompt ?? text.trim()
       const threadTs = payload.thread_ts ?? payload.ts
+      // bot がこのスレッドに初めて投稿する時だけ channel にも broadcast する。
+      // スレッドが既に立っている (継続) ときは中だけで完結させてノイズを抑える。
+      const broadcast = !inThread
       const initialMessages: ChatMessage[] =
         replies && botUserId
           ? buildChatMessages(replies, botUserId, prompt, payload.ts)
@@ -169,7 +177,7 @@ export function chat(
 
       const tools: Tool[] = [
         ...TOOLS,
-        buildSearchImageTool(context.say as SayFn, threadTs, jpiConfig),
+        buildSearchImageTool(context.say as SayFn, threadTs, broadcast, jpiConfig),
       ]
 
       try {
@@ -180,14 +188,14 @@ export function chat(
         await context.say({
           text: reply,
           thread_ts: threadTs,
-          reply_broadcast: true,
+          reply_broadcast: broadcast,
         })
       } catch (error) {
         logger.warn('chat: completion failed', { error: formatError(error) })
         await context.say({
           text: CHAT_APOLOGY,
           thread_ts: threadTs,
-          reply_broadcast: true,
+          reply_broadcast: broadcast,
         })
       }
     }),

--- a/src/slack/jpi.ts
+++ b/src/slack/jpi.ts
@@ -28,6 +28,8 @@ export function jpi(app: SlackApp<any> | SlackOAuthApp<any>, config: JpiConfig) 
         text: keyword,
         blocks: JSXSlack(jpiBlocks({ text: keyword, url: imageUrl })),
         link_names: false,
+        thread_ts: payload.thread_ts ?? payload.ts,
+        reply_broadcast: !payload.thread_ts,
       })
     }),
   )


### PR DESCRIPTION
## Summary
- bot がスレッドを **新規に開く** ときだけ \`reply_broadcast: true\` で channel に流す
- スレッドが既に立っているとき (\`payload.thread_ts\` 定義済み) は **broadcast せず** スレッド内に閉じる
- 対象: chat の通常応答 / apology fallback / search_image の画像投稿
- \`!jpi <keyword>\` も同じ挙動に統一: 元メッセージへのスレッド reply + 初回 broadcast

## Why
ずっと broadcast し続けると、スレッドの往復が全部 channel に出てしまってノイズになる。初回だけ broadcast すれば「bot が反応した」ことが channel から見える + 以降のやり取りはスレッド内で静かに進む。

## Test plan
- [x] \`npm test\` (全 72 件 pass)
- [x] \`npx tsc --noEmit\`
- [ ] merge → \`npm run deploy\`
- [ ] スレッド外で \`@jpi 猫の画像探して\` → 画像が thread に投稿 + channel にも broadcast される
- [ ] そのスレッド内で平文 \`もう一枚\` → AI / search_image の応答が thread 内のみ (channel には流れない)
- [ ] \`!jpi neko\` → 元メッセージへの thread reply として画像投稿 + broadcast